### PR TITLE
fixed generateArrayOfSuggestionsFrom null contact name issue

### DIFF
--- a/YesGraph/YesGraphSDK/YesGraphSDK/Network/YSGClient+SuggestionsShown.m
+++ b/YesGraph/YesGraphSDK/YesGraphSDK/Network/YSGClient+SuggestionsShown.m
@@ -19,10 +19,21 @@
     
     for (YSGContact *contact in suggestions)
     {
-        NSDictionary *seenContact = @
+		//
+		// Check if name is empty
+		//
+		
+		NSString *contact_name = contact.name;
+		
+		if (!contact_name)
+		{
+			contact_name = @"";
+		}
+		
+		NSDictionary *seenContact = @
         {
             @"user_id": userId,
-            @"name": contact.name,
+            @"name": contact_name,
             @"emails": contact.emails ?: emptyArray,
             @"phones": contact.phones ?: emptyArray,
             @"seen_at": seenAt

--- a/YesGraph/YesGraphSDK/YesGraphSDKTests/Tests/YesGraphSDKSuggestionsShownTests.m
+++ b/YesGraph/YesGraphSDK/YesGraphSDKTests/Tests/YesGraphSDKSuggestionsShownTests.m
@@ -36,7 +36,7 @@
 
 - (void)asyncSuggestionsShownWithExpectation:(XCTestExpectation *)expectation
 {
-    NSArray *shownSuggestions = [[YSGTestMockData mockContactList].entries subarrayWithRange:NSMakeRange(0, 5)];
+    NSArray *shownSuggestions = [[YSGTestMockData mockContactList].entries subarrayWithRange:NSMakeRange(0, 10)];
     
     [self.client updateSuggestionsSeen:shownSuggestions forUserId:YSGTestClientID completion:^(NSError * _Nullable error)
     {
@@ -79,7 +79,7 @@
          NSArray *sentSuggestions = parsedResponse[@"entries"];
          XCTAssertNotNil(sentSuggestions, @"Request body is missing entries");
 
-         NSArray *expectedSuggestions = [[YSGTestMockData mockContactList].entries subarrayWithRange:NSMakeRange(0, 5)];
+         NSArray *expectedSuggestions = [[YSGTestMockData mockContactList].entries subarrayWithRange:NSMakeRange(0, 10)];
          XCTAssert(expectedSuggestions.count == sentSuggestions.count, @"Arrays don't have the same number of elements");
          for (NSInteger index = 0; index < expectedSuggestions.count; ++index)
          {
@@ -92,7 +92,7 @@
 
              NSString *contactName = sentContact[@"name"];
              XCTAssertNotNil(contactName, @"Contact name shouldn't be nil");
-             XCTAssert([contactName isEqualToString:contact.name]);
+             XCTAssert([contactName isEqualToString:contact.name] || [contactName isEqualToString:@""]);
 
              NSArray *contactEmails = sentContact[@"emails"];
              XCTAssertNotNil(contactEmails, @"Contact emails shouldn't be nil (should be empty array)");


### PR DESCRIPTION
#### What’s this PR do?
- fixes the case where some contacts don't have a name in the generateArrayOfSuggestionsFrom method.

#### Where should the reviewer start?
run the tests

#### How should this be manually tested?
run it on a phone where some contacts don't have names, if it don't crash, it's good

#### Any background context you want to provide?
discovered by wishbone

#### What are the relevant tickets?
https://app.asana.com/0/60637562121030/117497730621816
