### PR TITLE
Add Convenience Methods for Contact List to YesGraph.h/m

### DIFF
--- a/YesGraph-iOS-SDK.podspec
+++ b/YesGraph-iOS-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                      = "YesGraph-iOS-SDK"
-  s.version                   = "1.0.3"
+  s.version                   = "1.0.4"
   s.summary                   = "Official YesGraph SDK for iOS to access YesGraph API and integrate YesGraph Invite Flow"
 
   s.description               = <<-DESC

--- a/YesGraph/YesGraphSDK/YesGraphSDK/Service/Invite/Source/YSGOnlineContactSource.h
+++ b/YesGraph/YesGraphSDK/YesGraphSDK/Service/Invite/Source/YSGOnlineContactSource.h
@@ -55,6 +55,23 @@ NS_ASSUME_NONNULL_BEGIN
                                 
 @interface YSGOnlineContactSource (SuggestionsShown)
 
+
+/*!
+ *  This retrieves the contact list from the app cache if it exists, otherwise it retrieves it from the phone. Then it uploads
+ * to YesGraph and runs the completion on the results.
+ */
+- (void)fetchContactListWithCompletion:(void (^)(YSGContactList *, NSError *))completion;
+
+/*!
+ *  This method retrieves the contact list from the phone, uploads them to YesGraph, and runs the completion on the response
+ */
+- (void)updateAndUploadContactListWithCompletion:(void (^)(YSGContactList *, NSError *))completion;
+
+/*!
+ * This method uploads a contact list to YesGraph.
+ */
+- (void)uploadContactList:(YSGContactList *)contactList completion:(void (^)(YSGContactList *, NSError *))completion;
+
 /*!
  *  Every time the suggestions list is shown, it is sent to the YesGraph API
  */

--- a/YesGraph/YesGraphSDK/YesGraphSDKTests/Library/YSGMockClient.m
+++ b/YesGraph/YesGraphSDK/YesGraphSDKTests/Library/YSGMockClient.m
@@ -9,6 +9,7 @@
 #import "YSGMockClient.h"
 #import "YSGClient+AddressBook.h"
 #import "YSGClient+SuggestionsShown.h"
+#import "YSGClient+AddressBookBatchPost.h"
 #import "YSGTestMockData.h"
 #import "YSGTestSettings.h"
 #import "objc/runtime.h"
@@ -30,6 +31,39 @@
         }
     }
 }
+
+- (void)updateAddressBookWithContactList:(YSGContactList *)contactList forUserId:(NSString *)userId completion:(YSGNetworkFetchCompletion)completion
+{
+    if (completion)
+    {
+        if (self.shouldSucceed)
+        {
+            completion([YSGTestMockData mockContactList], nil);
+        }
+        else
+        {
+            NSError *sentError = [NSError errorWithDomain:@"YesGraphSDKDomain" code:2 userInfo:nil];
+            completion(nil, sentError);
+        }
+    }
+}
+
+- (void)updateAddressBookWithContactList:(YSGContactList *)contactList forUserId:(NSString *)userId completionWaitForFinish:(BOOL)waitForFinish completion:(nullable YSGNetworkFetchCompletion)completion
+{
+    if (completion)
+    {
+        if (self.shouldSucceed)
+        {
+            completion([YSGTestMockData mockContactList], nil);
+        }
+        else
+        {
+            NSError *sentError = [NSError errorWithDomain:@"YesGraphSDKDomain" code:2 userInfo:nil];
+            completion(nil, sentError);
+        }
+    }
+}
+
 
 - (void)updateSuggestionsSeen:(NSArray<YSGContact *> *)suggestionsShown forUserId:(NSString *)userId completion:(void (^)(NSError * _Nullable))completion
 {

--- a/YesGraph/YesGraphSDK/YesGraphSDKTests/Library/YesGraph+Private.h
+++ b/YesGraph/YesGraphSDK/YesGraphSDKTests/Library/YesGraph+Private.h
@@ -25,6 +25,6 @@
 @property (nonatomic, copy) NSDate* lastFetchDate;
 
 - (void)applicationNotification:(NSNotification *)notification;
-- (void)updateContactList:(YSGContactList *)contactList;
+- (void)updateYesGraphWithContactList:(YSGContactList *)contactList;
 
 @end

--- a/YesGraph/YesGraphSDK/YesGraphSDKTests/Tests/YesGraphSDKOnlineContactSourceTests.m
+++ b/YesGraph/YesGraphSDK/YesGraphSDKTests/Tests/YesGraphSDKOnlineContactSourceTests.m
@@ -7,6 +7,8 @@
 //
 
 @import XCTest;
+@import OCMock;
+
 #import "YSGMockClient.h"
 #import "YSGOnlineContactSource.h"
 #import "YSGCacheContactSource.h"
@@ -84,6 +86,30 @@
          XCTAssertNil(error, @"Error should be nil not '%@', otherwise the message handler was never invoked", error);
      }];
 }
+
+- (void)testUploadContactList
+{
+    YSGMockClient *mockedClient = [YSGMockClient createMockedClient:YES];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Expect Fetch Online Contact List"];
+    __weak YSGContactList *expectedContactsList = [YSGTestMockData mockContactList];
+    
+    YSGOnlineContactSource *onlineSource = [[YSGOnlineContactSource alloc] initWithClient:mockedClient localSource:self.localSource cacheSource:self.cacheSource];
+    __weak YSGOnlineContactSource *preventRetainCycleInstance = onlineSource;
+
+    [preventRetainCycleInstance uploadContactList: expectedContactsList completion:^(YSGContactList *returnedContacts, NSError *error)
+     {
+         XCTAssertNil(error, @"Error is supposed to be nil, not '%@'", error);
+         XCTAssertEqual(returnedContacts.entries.count, expectedContactsList.entries.count, @"Returned contacts should contain '%lu' entries, not '%lu'", (unsigned long)expectedContactsList.entries.count, (unsigned long)returnedContacts.entries.count);
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError * _Nullable error)
+     {
+         XCTAssertNil(error, @"Error should be nil not '%@', otherwise the message handler was never invoked", error);
+     }];
+}
+
 
 - (void)testUpdateShownSuggestions
 {


### PR DESCRIPTION
This PR adds convenience methods for handling the contact list to YesGraph.h/m. This will enable simpler access to the API, since YesGraph.m sets up the local, cache, and online sources internally so the developer should not have to reproduce this effort.